### PR TITLE
feat: Adding more arguments to Worker.log()

### DIFF
--- a/src/clustering/worker/Thread.ts
+++ b/src/clustering/worker/Thread.ts
@@ -5,6 +5,8 @@ import { Worker } from "../../typings/lib"
 
 import { ResolveFunction, ThreadComms, ThreadEvents } from "../ThreadComms";
 
+import { inspect } from "util";
+
 import handlers from './handlers'
 
 export class Thread extends ThreadComms {
@@ -35,10 +37,10 @@ export class Thread extends ThreadComms {
 
   /**
    * Logs data to master's MasterOptions.log
-   * @param message Message string
+   * @param message Message args
    */
-  log (message: string) {
-    this.tell('LOG', message)
+  log (messages: ...any) {
+    this.tell('LOG', messages.map(m => typeof m === 'string' ? m : inspect(m)).join(' '))
   }
 
   /**

--- a/src/clustering/worker/Worker.ts
+++ b/src/clustering/worker/Worker.ts
@@ -114,7 +114,7 @@ export class Worker extends Emitter<DiscordEventMap> {
     return this.api instanceof RestManager && this.shards.every(x => x.ready)
   }
 
-  log (data: string) {
-    this.comms.tell('LOG', data)
+  log (...data: any) {
+    this.comms.tell('LOG', data.map(d => typeof d === 'string' ? d : inspect(d)).join(' '))
   }
 }

--- a/src/clustering/worker/Worker.ts
+++ b/src/clustering/worker/Worker.ts
@@ -5,6 +5,8 @@ import { DiscordEventMap, CachedGuild } from '../../typings/Discord'
 import { Emitter } from '../../utils/Emitter'
 import Collection from '@discordjs/collection'
 
+import { inspect } from "util"
+
 import { Shard } from '../../socket/Shard'
 import { CacheManager } from '../../socket/CacheManager'
 


### PR DESCRIPTION
Adding the ability to do `Worker.log()` with more than just 1 string.

Before:
```js
worker.log('this is', 'a test');
// this is
```

Now:
```js
worker.log('this is', 'a test', { 'Hello': 'World' })
// this is a test { Hello: 'World' }
```