### PR TITLE
bug fix: Fix 404 when editing member nicknames

### DIFF
--- a/src/rest/resources/Members.ts
+++ b/src/rest/resources/Members.ts
@@ -39,11 +39,24 @@ export class MembersResource {
   /**
    * Sets a members nickname
    * @param guildId ID of guild
-   * @param id ID of member (or leave blank for self)
-   * @param nick New nickname (null to reset)
+   * @param memberId ID of member
+   * @param nick New nickname (blank or null to reset)
    */
-  setNickname (guildId: Snowflake, memberId: Snowflake | '@me' = '@me', nick?: string): Promise<RESTPatchAPICurrentGuildMemberNicknameResult> {
+  setNickname(guildId: Snowflake, memberId: Snowflake, nick: string | null = null): Promise<RESTPatchAPIGuildMemberResult> {
     return this.edit(guildId, memberId, { nick })
+  }
+
+  /**
+   * Sets the bot's nickname
+   * @param guildId ID of guild
+   * @param nick New nickname (blank or null to reset)
+   */
+  setSelfNickname(guildId: Snowflake, nick: string | null = null): Promise<RESTPatchAPIGuildMemberResult> {
+    return this.rest.request('PATCH', `/guilds/${guildId}/members/@me/nick`, {
+      body: {
+        nick
+      }
+    })
   }
 
   /**

--- a/src/rest/resources/Members.ts
+++ b/src/rest/resources/Members.ts
@@ -43,11 +43,7 @@ export class MembersResource {
    * @param nick New nickname (null to reset)
    */
   setNickname (guildId: Snowflake, memberId: Snowflake | '@me' = '@me', nick?: string): Promise<RESTPatchAPICurrentGuildMemberNicknameResult> {
-    return this.rest.request('PATCH', `/guilds/${guildId}/members/${memberId}/nick`, {
-      body: {
-        nick
-      }
-    })
+    return this.edit(guildId, memberId, { nick })
   }
 
   /**


### PR DESCRIPTION
Fixing a 404 error from the `Members.setNickname()`

Before:
```js
worker.api.members.setNickname('810951119731294218', '142408079177285632', 'Stinky')
// DiscordAPIError: 404: Not Found
```

Now:
```js
worker.api.members.setNickname('810951119731294218', '142408079177285632', 'Stinky')
// DiscordAPIError: Missing Permissions
```