### PR TITLE
feat: Adding getter `author` to class `CommandContext`

### DIFF
--- a/src/structures/CommandContext.ts
+++ b/src/structures/CommandContext.ts
@@ -1,4 +1,4 @@
-import { APIGuildMember, APIMessage, APIChannel, Snowflake } from 'discord-api-types'
+import { APIGuildMember, APIMessage, APIChannel, Snowflake, APIUser } from 'discord-api-types'
 
 import { Embed } from './Embed'
 import { MessageTypes, MessagesResource, Emoji } from '../rest/resources/Messages'
@@ -46,6 +46,13 @@ export class CommandContext {
     this.prefix = opts.prefix
     this.ran = opts.ran
     this.args = opts.args
+  }
+
+  /**
+   * Author of the message
+   */
+  get author (): APIUser {
+    return this.message.author
   }
 
   /**


### PR DESCRIPTION
Since there were already `guild` and `channel` getters on `CommandContext`, it makes sense to have an `author` getter.
Rather than doing 
```js
const author = ctx.message.author
```
It is possible to do 
```js
const author = ctx.author
```