### PR TITLE
feat: Adding `getAuditLog` to `GuildsResource`

### DIFF
--- a/src/rest/resources/Guilds.ts
+++ b/src/rest/resources/Guilds.ts
@@ -1,4 +1,4 @@
-import { RESTGetAPIGuildQuery, RESTGetAPIGuildRolesResult, RESTPatchAPIGuildJSONBody, RESTPatchAPIGuildRoleJSONBody, RESTPatchAPIGuildRoleResult, RESTPostAPIGuildRoleJSONBody, RESTPostAPIGuildRoleResult, Snowflake } from 'discord-api-types'
+import { RESTGetAPIAuditLogResult, RESTGetAPIAuditLogQuery, RESTGetAPIGuildQuery, RESTGetAPIGuildRolesResult, RESTPatchAPIGuildJSONBody, RESTPatchAPIGuildRoleJSONBody, RESTPatchAPIGuildRoleResult, RESTPostAPIGuildRoleJSONBody, RESTPostAPIGuildRoleResult, Snowflake } from 'discord-api-types'
 import { RestManager } from '../Manager'
 
 /**
@@ -77,5 +77,16 @@ export class GuildsResource {
    */
   async deleteRole (guildId: Snowflake, roleId: Snowflake): Promise<never> {
     return this.rest.request('DELETE', `/guilds/${guildId}/roles/${roleId}`) as never
+  }
+
+  /**
+   * Gets audit-log entries
+   * @param guildId ID of guild
+   * @param data Query paramaters
+   */
+  async getAuditLog(guildId: Snowflake, query: RESTGetAPIAuditLogQuery): Promise<RESTGetAPIAuditLogResult> {
+    return this.rest.request('GET', `/guilds/${guildId}/audit-logs`, {
+      query: query
+    })
   }
 }

--- a/src/rest/resources/Guilds.ts
+++ b/src/rest/resources/Guilds.ts
@@ -84,7 +84,7 @@ export class GuildsResource {
    * @param guildId ID of guild
    * @param data Query paramaters
    */
-  async getAuditLog(guildId: Snowflake, query: RESTGetAPIAuditLogQuery): Promise<RESTGetAPIAuditLogResult> {
+  async getAuditLog (guildId: Snowflake, query: RESTGetAPIAuditLogQuery): Promise<RESTGetAPIAuditLogResult> {
     return this.rest.request('GET', `/guilds/${guildId}/audit-logs`, {
       query: query
     })

--- a/src/rest/resources/Guilds.ts
+++ b/src/rest/resources/Guilds.ts
@@ -86,7 +86,7 @@ export class GuildsResource {
    */
   async getAuditLog (guildId: Snowflake, query: RESTGetAPIAuditLogQuery): Promise<RESTGetAPIAuditLogResult> {
     return await this.rest.request('GET', `/guilds/${guildId}/audit-logs`, {
-      query: query
+      query
     })
   }
 }

--- a/src/rest/resources/Guilds.ts
+++ b/src/rest/resources/Guilds.ts
@@ -85,7 +85,7 @@ export class GuildsResource {
    * @param data Query paramaters
    */
   async getAuditLog (guildId: Snowflake, query: RESTGetAPIAuditLogQuery): Promise<RESTGetAPIAuditLogResult> {
-    return this.rest.request('GET', `/guilds/${guildId}/audit-logs`, {
+    return await this.rest.request('GET', `/guilds/${guildId}/audit-logs`, {
       query: query
     })
   }


### PR DESCRIPTION
Adding support for requests to a guild's audit-logs
example:
```js
// In a command
ctx.worker.api.guilds.getAuditLog(ctx.guild.id, {
  user_id: '142408079177285632',
  action_type: 22,
  limit: 10
})
  .then(logs => {
    ctx.send(
      'Members Banned:\n' +
      logs.audit_log_entries
        .map(entry => `<@${entry.target_id}>`)
        .join(', ')
      )
  })
  .catch(err => { ctx.error(err) })
```