### PR TITLE
Adding permissions check to default error handler

### DIFF
--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -43,11 +43,19 @@ export class CommandHandler {
 
   public prefixFunction?: ((message: APIMessage) => Promise<string|string[]> | string|string[])
   public errorFunction = (ctx: ctx, err: CommandError): void => {
-    ctx.embed
-      .color(0xFF0000)
-      .title('An Error Occured')
-      .description(`\`\`\`xl\n${err.message}\`\`\``)
-      .send().catch(() => {})
+    if (ctx.myPerms('sendMessages')) {
+      if (ctx.myPerms('embed')) {
+        ctx.embed
+          .color(0xFF0000)
+          .title('An Error Occured')
+          .description(`\`\`\`xl\n${err.message}\`\`\``)
+          .send().catch(() => { })
+      } else {
+        ctx
+          .send(`An Error Occured\n\`\`\`xl\n${err.message}\`\`\``)
+          .catch(() => { })
+      }
+    }
 
     if (err.nonFatal) return
 


### PR DESCRIPTION
Adding a check for `sendMessages` and `embed` permissions in the default error handler. This will, if the channel and guild is cached, reduce the number of unnecessary API requests assuming the permissions are not given.

Additionally, it would make sense for the permissions check to be put in `CommandContext.send` and `CommandContext.reply` in order to further reduce unnecessary API requests.