### PR TITLE
feat: "Finalizers" in default command handler

### DIFF
--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -114,11 +114,11 @@ export class CommandHandler {
    * @param fn String of prefix or Function to choose prefix with
    * @example
    * worker.commands
-   *   .setPrefix('!')
+   *   .prefix('!')
    * // or
-   *   .setPrefix(['!', '+'])
+   *   .prefix(['!', '+'])
    * // or
-   *   .setPrefix((message) => {
+   *   .prefix((message) => {
    *     return db.getPrefix(message.guild_id)
    *   })
    * @returns this

--- a/src/typings/lib.ts
+++ b/src/typings/lib.ts
@@ -16,7 +16,7 @@ namespace DiscordRose {
     /**
      * Execute function
      */
-    exec: (ctx: CommandContext) => void | Promise<void>
+    exec: (ctx: CommandContext) => any | Promise<any>
   }
   export interface CommandContext extends ctx {}
   export type Worker = worker


### PR DESCRIPTION
These "finalizers" allow for different functions to be ran based on the output of the command. For example, one could do
```js
worker.commands
  .finalizer((r, ctx) => {
    if (r === true) ctx.invokeCooldown()
  })
```
which would invoke a cooldown on every successful command.

I also fixed a typo on the example of the `CommandHandler.prefix` function.