### PR TITLE
feat: Add `reuseInteractions` option to `CommandHandler`

### DIFF
--- a/src/rest/resources/Interactions.ts
+++ b/src/rest/resources/Interactions.ts
@@ -1,4 +1,4 @@
-import { InteractionResponseType, RESTPatchAPIApplicationCommandJSONBody, RESTPatchAPIApplicationCommandResult, RESTPatchAPIApplicationGuildCommandJSONBody, RESTPatchAPIApplicationGuildCommandResult, RESTPostAPIInteractionCallbackJSONBody, RESTPutAPIApplicationCommandsJSONBody, RESTPutAPIApplicationCommandsResult, RESTPutAPIApplicationGuildCommandsJSONBody, RESTPutAPIApplicationGuildCommandsResult, Snowflake } from 'discord-api-types'
+import { InteractionResponseType, RESTGetAPIApplicationCommandsResult, RESTGetAPIApplicationGuildCommandsResult, RESTPatchAPIApplicationCommandJSONBody, RESTPatchAPIApplicationCommandResult, RESTPatchAPIApplicationGuildCommandJSONBody, RESTPatchAPIApplicationGuildCommandResult, RESTPostAPIInteractionCallbackJSONBody, RESTPutAPIApplicationCommandsJSONBody, RESTPutAPIApplicationCommandsResult, RESTPutAPIApplicationGuildCommandsJSONBody, RESTPutAPIApplicationGuildCommandsResult, Snowflake } from 'discord-api-types'
 import FormData from 'form-data'
 import { RestManager } from '../Manager'
 import { MessagesResource, MessageTypes } from './Messages'
@@ -18,6 +18,15 @@ export class InteractionResource {
     return await this.rest.request('PUT', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands`, {
       body: data
     })
+  }
+
+  /**
+   * Gets all posted commands for an application
+   * @param applicationId Application/client ID
+   * @param guildId Optional guild ID to only get commands for specific guild
+   */
+  async get (applicationId: Snowflake, guildId?: Snowflake): Promise<RESTGetAPIApplicationCommandsResult | RESTGetAPIApplicationGuildCommandsResult> {
+    return await this.rest.request('GET', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands`)
   }
 
   /**

--- a/src/rest/resources/Interactions.ts
+++ b/src/rest/resources/Interactions.ts
@@ -54,11 +54,11 @@ export class InteractionResource {
   /**
    * Updates/upserts a specific command
    * @param data Interaction data
-   * @param interactionId Interaction ID
    * @param applicationId Application/client ID
+   * @param interactionId Interaction ID
    * @param guildId Optional guild ID to only update a command for a specific guild
    */
-  async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, interactionId: Snowflake, applicationId: Snowflake, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
+  async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, applicationId: Snowflake, interactionId: Snowflake, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
     return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${interactionId}`, {
       body: data
     })

--- a/src/rest/resources/Interactions.ts
+++ b/src/rest/resources/Interactions.ts
@@ -1,4 +1,4 @@
-import { InteractionResponseType, RESTGetAPIApplicationCommandsResult, RESTGetAPIApplicationGuildCommandsResult, RESTPatchAPIApplicationCommandJSONBody, RESTPatchAPIApplicationCommandResult, RESTPatchAPIApplicationGuildCommandJSONBody, RESTPatchAPIApplicationGuildCommandResult, RESTPostAPIInteractionCallbackJSONBody, RESTPutAPIApplicationCommandsJSONBody, RESTPutAPIApplicationCommandsResult, RESTPutAPIApplicationGuildCommandsJSONBody, RESTPutAPIApplicationGuildCommandsResult, Snowflake } from 'discord-api-types'
+import { InteractionResponseType, RESTGetAPIApplicationCommandsResult, RESTGetAPIApplicationGuildCommandsResult, RESTPatchAPIApplicationCommandJSONBody, RESTPatchAPIApplicationCommandResult, RESTPatchAPIApplicationGuildCommandJSONBody, RESTPatchAPIApplicationGuildCommandResult, RESTPostAPIApplicationCommandsJSONBody, RESTPostAPIApplicationCommandsResult,  RESTPostAPIApplicationGuildCommandsJSONBody, RESTPostAPIApplicationGuildCommandsResult, RESTPostAPIInteractionCallbackJSONBody, RESTPutAPIApplicationCommandsJSONBody, RESTPutAPIApplicationCommandsResult, RESTPutAPIApplicationGuildCommandsJSONBody, RESTPutAPIApplicationGuildCommandsResult, Snowflake } from 'discord-api-types'
 import FormData from 'form-data'
 import { RestManager } from '../Manager'
 import { MessagesResource, MessageTypes } from './Messages'
@@ -30,14 +30,13 @@ export class InteractionResource {
   }
 
   /**
-   * Updates/upserts a specific command
+   * Adds a command for an application
    * @param data Interaction data
    * @param applicationId Application/client ID
-   * @param commandId Command ID to replace
-   * @param guildId Optional guild ID to only set command to specific guild
+   * @param guildId Optional guild ID to only set commands for specific guild
    */
-  async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, applicationId: Snowflake, commandId?: string, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
-    return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${commandId ?? data.name}`, {
+  async add (data: RESTPostAPIApplicationCommandsJSONBody | RESTPostAPIApplicationGuildCommandsJSONBody, applicationId: Snowflake, guildId?: Snowflake): Promise<RESTPostAPIApplicationCommandsResult | RESTPostAPIApplicationGuildCommandsResult> {
+    return await this.rest.request('POST', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands`, {
       body: data
     })
   }
@@ -50,6 +49,19 @@ export class InteractionResource {
    */
   async delete (interactionId: Snowflake, applicationId: Snowflake, guildId?: Snowflake): Promise<void> {
     await this.rest.request('DELETE', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}/commands/${interactionId}`)
+  }
+
+  /**
+   * Updates/upserts a specific command
+   * @param data Interaction data
+   * @param applicationId Application/client ID
+   * @param commandId Command ID to replace
+   * @param guildId Optional guild ID to only set command to specific guild
+   */
+   async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, applicationId: Snowflake, commandId?: string, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
+    return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${commandId ?? data.name}`, {
+      body: data
+    })
   }
 
   /**

--- a/src/rest/resources/Interactions.ts
+++ b/src/rest/resources/Interactions.ts
@@ -59,7 +59,7 @@ export class InteractionResource {
    * @param guildId Optional guild ID to only set command to specific guild
    */
   async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, applicationId: Snowflake, commandId?: string, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
-    return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${commandId ?? data.name}`, {
+    return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${(commandId ?? data.name) ?? ''}`, {
       body: data
     })
   }

--- a/src/rest/resources/Interactions.ts
+++ b/src/rest/resources/Interactions.ts
@@ -23,7 +23,7 @@ export class InteractionResource {
   /**
    * Gets all posted commands for an application
    * @param applicationId Application/client ID
-   * @param guildId Optional guild ID to only get commands for specific guild
+   * @param guildId Optional guild ID to only get commands from a specific guild
    */
   async get (applicationId: Snowflake, guildId?: Snowflake): Promise<RESTGetAPIApplicationCommandsResult | RESTGetAPIApplicationGuildCommandsResult> {
     return await this.rest.request('GET', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands`)
@@ -33,7 +33,7 @@ export class InteractionResource {
    * Adds a command for an application
    * @param data Interaction data
    * @param applicationId Application/client ID
-   * @param guildId Optional guild ID to only set commands for specific guild
+   * @param guildId Optional guild ID to only add a command for a specific guild
    */
   async add (data: RESTPostAPIApplicationCommandsJSONBody | RESTPostAPIApplicationGuildCommandsJSONBody, applicationId: Snowflake, guildId?: Snowflake): Promise<RESTPostAPIApplicationCommandsResult | RESTPostAPIApplicationGuildCommandsResult> {
     return await this.rest.request('POST', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands`, {
@@ -42,7 +42,7 @@ export class InteractionResource {
   }
 
   /**
-   * Deletes a specific command
+   * Deletes a specific command for an application
    * @param interactionId Interaction ID
    * @param applicationId Application/client ID
    * @param guildId Optional guild ID to only delete a command for a specific guild
@@ -56,7 +56,7 @@ export class InteractionResource {
    * @param data Interaction data
    * @param interactionId Interaction ID
    * @param applicationId Application/client ID
-   * @param guildId Optional guild ID to only set command to specific guild
+   * @param guildId Optional guild ID to only update a command for a specific guild
    */
   async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, interactionId: Snowflake, applicationId: Snowflake, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
     return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${interactionId}`, {
@@ -66,7 +66,7 @@ export class InteractionResource {
 
   /**
    * Responds to an interaction
-   * @param interactionId Interact ID
+   * @param interactionId Interaction ID
    * @param interactionToken Interaction Token
    * @param data Interaction Callback Data
    */

--- a/src/rest/resources/Interactions.ts
+++ b/src/rest/resources/Interactions.ts
@@ -1,4 +1,4 @@
-import { InteractionResponseType, RESTGetAPIApplicationCommandsResult, RESTGetAPIApplicationGuildCommandsResult, RESTPatchAPIApplicationCommandJSONBody, RESTPatchAPIApplicationCommandResult, RESTPatchAPIApplicationGuildCommandJSONBody, RESTPatchAPIApplicationGuildCommandResult, RESTPostAPIApplicationCommandsJSONBody, RESTPostAPIApplicationCommandsResult,  RESTPostAPIApplicationGuildCommandsJSONBody, RESTPostAPIApplicationGuildCommandsResult, RESTPostAPIInteractionCallbackJSONBody, RESTPutAPIApplicationCommandsJSONBody, RESTPutAPIApplicationCommandsResult, RESTPutAPIApplicationGuildCommandsJSONBody, RESTPutAPIApplicationGuildCommandsResult, Snowflake } from 'discord-api-types'
+import { InteractionResponseType, RESTGetAPIApplicationCommandsResult, RESTGetAPIApplicationGuildCommandsResult, RESTPatchAPIApplicationCommandJSONBody, RESTPatchAPIApplicationCommandResult, RESTPatchAPIApplicationGuildCommandJSONBody, RESTPatchAPIApplicationGuildCommandResult, RESTPostAPIApplicationCommandsJSONBody, RESTPostAPIApplicationCommandsResult, RESTPostAPIApplicationGuildCommandsJSONBody, RESTPostAPIApplicationGuildCommandsResult, RESTPostAPIInteractionCallbackJSONBody, RESTPutAPIApplicationCommandsJSONBody, RESTPutAPIApplicationCommandsResult, RESTPutAPIApplicationGuildCommandsJSONBody, RESTPutAPIApplicationGuildCommandsResult, Snowflake } from 'discord-api-types'
 import FormData from 'form-data'
 import { RestManager } from '../Manager'
 import { MessagesResource, MessageTypes } from './Messages'
@@ -58,7 +58,7 @@ export class InteractionResource {
    * @param commandId Command ID to replace
    * @param guildId Optional guild ID to only set command to specific guild
    */
-   async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, applicationId: Snowflake, commandId?: string, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
+  async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, applicationId: Snowflake, commandId?: string, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
     return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${commandId ?? data.name}`, {
       body: data
     })

--- a/src/rest/resources/Interactions.ts
+++ b/src/rest/resources/Interactions.ts
@@ -54,12 +54,12 @@ export class InteractionResource {
   /**
    * Updates/upserts a specific command
    * @param data Interaction data
+   * @param interactionId Interaction ID
    * @param applicationId Application/client ID
-   * @param commandId Command ID to replace
    * @param guildId Optional guild ID to only set command to specific guild
    */
-  async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, applicationId: Snowflake, commandId?: string, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
-    return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${(commandId ?? data.name) ?? ''}`, {
+  async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, interactionId: Snowflake, applicationId: Snowflake, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
+    return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${interactionId}`, {
       body: data
     })
   }

--- a/src/rest/resources/Interactions.ts
+++ b/src/rest/resources/Interactions.ts
@@ -1,4 +1,4 @@
-import { InteractionResponseType, RESTPostAPIApplicationCommandsJSONBody, RESTPostAPIApplicationCommandsResult, RESTPostAPIInteractionCallbackJSONBody, RESTPutAPIApplicationCommandsJSONBody, Snowflake } from 'discord-api-types'
+import { InteractionResponseType, RESTPatchAPIApplicationCommandJSONBody, RESTPatchAPIApplicationCommandResult, RESTPatchAPIApplicationGuildCommandJSONBody, RESTPatchAPIApplicationGuildCommandResult, RESTPostAPIInteractionCallbackJSONBody, RESTPutAPIApplicationCommandsJSONBody, RESTPutAPIApplicationCommandsResult, RESTPutAPIApplicationGuildCommandsJSONBody, RESTPutAPIApplicationGuildCommandsResult, Snowflake } from 'discord-api-types'
 import FormData from 'form-data'
 import { RestManager } from '../Manager'
 import { MessagesResource, MessageTypes } from './Messages'
@@ -14,7 +14,7 @@ export class InteractionResource {
    * @param applicationId Application/client ID
    * @param guildId Optional guild ID to only set commands for specific guild
    */
-  async set (data: RESTPutAPIApplicationCommandsJSONBody, applicationId: Snowflake, guildId?: Snowflake): Promise<RESTPostAPIApplicationCommandsResult> {
+  async set (data: RESTPutAPIApplicationCommandsJSONBody | RESTPutAPIApplicationGuildCommandsJSONBody, applicationId: Snowflake, guildId?: Snowflake): Promise<RESTPutAPIApplicationCommandsResult | RESTPutAPIApplicationGuildCommandsResult> {
     return await this.rest.request('PUT', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands`, {
       body: data
     })
@@ -27,7 +27,7 @@ export class InteractionResource {
    * @param commandId Command ID to replace
    * @param guildId Optional guild ID to only set command to specific guild
    */
-  async update (data: RESTPostAPIApplicationCommandsJSONBody, applicationId: Snowflake, commandId?: string, guildId?: Snowflake): Promise<RESTPostAPIApplicationCommandsResult> {
+  async update (data: RESTPatchAPIApplicationCommandJSONBody | RESTPatchAPIApplicationGuildCommandJSONBody, applicationId: Snowflake, commandId?: string, guildId?: Snowflake): Promise<RESTPatchAPIApplicationCommandResult | RESTPatchAPIApplicationGuildCommandResult> {
     return await this.rest.request('PATCH', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}commands/${commandId ?? data.name}`, {
       body: data
     })

--- a/src/rest/resources/Interactions.ts
+++ b/src/rest/resources/Interactions.ts
@@ -43,6 +43,16 @@ export class InteractionResource {
   }
 
   /**
+   * Deletes a specific command
+   * @param interactionId Interaction ID
+   * @param applicationId Application/client ID
+   * @param guildId Optional guild ID to only delete a command for a specific guild
+   */
+  async delete (interactionId: Snowflake, applicationId: Snowflake, guildId?: Snowflake): Promise<void> {
+    await this.rest.request('DELETE', `/applications/${applicationId}/${guildId ? `/guilds/${guildId}/` : ''}/commands/${interactionId}`)
+  }
+
+  /**
    * Responds to an interaction
    * @param interactionId Interact ID
    * @param interactionToken Interaction Token

--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -33,7 +33,7 @@ export class CommandHandler {
     mentionPrefix: true,
     caseInsensitivePrefix: true,
     caseInsensitiveCommand: true,
-    reuseInteractions: false
+    reuseInteractions: true
   }
 
   public middlewares: MiddlewareFunction[] = []
@@ -424,7 +424,7 @@ export interface CommandHandlerOptions {
   interactionGuild?: Snowflake
   /**
    * If interactions previously posted should be reused when possible
-   * @default false
+   * @default true
    */
   reuseInteractions?: boolean
 }

--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -70,10 +70,6 @@ export class CommandHandler {
             interaction.options === command.interaction?.options
           ) && !newInteractions.find(newCommand => newCommand === command))
 
-          console.log(newInteractions)
-          console.log(deletedInteractions)
-          console.log(changedInteractions)
-
           const promises: Array<Promise<any>> = []
           newInteractions.forEach(command => promises.push(this.worker.api.interactions.add(command.interaction as RESTPostAPIApplicationCommandsJSONBody, this.worker.user.id, this._options.interactionGuild)))
           deletedInteractions.forEach(interaction => promises.push(this.worker.api.interactions.delete(interaction.id, this.worker.user.id, this._options.interactionGuild)))

--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -243,7 +243,7 @@ export class CommandHandler {
       })
 
       this.worker.once('READY', () => {
-        this.setupInteractions()
+        void this.setupInteractions()
       })
     }
     if (this.worker.comms.id === '0' && this.addedInteractions && command.interaction) {

--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -85,12 +85,7 @@ export class CommandHandler {
 
           newInteractions.forEach(command => promises.push(this.worker.api.interactions.add(command.interaction as RESTPostAPIApplicationCommandsJSONBody, this.worker.user.id, this._options.interactionGuild)))
           deletedInteractions.forEach(interaction => promises.push(this.worker.api.interactions.delete(interaction.id, this.worker.user.id, this._options.interactionGuild)))
-          changedInteractions.forEach(command => {
-            const changedInteraction = currentInteractions.find(interaction => interaction.name === command.interaction?.name)
-            if (changedInteraction) {
-              promises.push(this.worker.api.interactions.update(command.interaction as RESTPatchAPIApplicationCommandJSONBody, changedInteraction.id, this.worker.user.id, this._options.interactionGuild))
-            }
-          })
+          changedInteractions.forEach(command => promises.push(this.worker.api.interactions.add(command.interaction as RESTPostAPIApplicationCommandsJSONBody, this.worker.user.id, this._options.interactionGuild)))
 
           Promise.all(promises)
             .then(() => {

--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -61,16 +61,20 @@ export class CommandHandler {
         if (this._options.reuseInteractions) {
           const currentInteractions = await this.worker.api.interactions.get(this.worker.user.id, this._options.interactionGuild)
 
-          const newInteractions = interactions.filter(command => !!!currentInteractions.find(interaction => command.interaction?.name === interaction.name))
-          const deletedInteractions = currentInteractions.filter(interaction => !!!interactions.find(command => interaction.name === command.interaction?.name))
-          const changedInteractions = interactions.filter(command => !!!currentInteractions.find(interaction =>
+          const newInteractions = interactions.filter(command => !currentInteractions.find(interaction => command.interaction?.name === interaction.name))
+          const deletedInteractions = currentInteractions.filter(interaction => !interactions.find(command => interaction.name === command.interaction?.name))
+          const changedInteractions = interactions.filter(command => !currentInteractions.find(interaction =>
             interaction.default_permission === (typeof command.interaction?.default_permission === 'boolean' ? command.interaction?.default_permission : true) &&
             interaction.description === command.interaction?.description &&
             interaction.name === command.interaction?.name &&
             interaction.options === command.interaction?.options
-          ) && !!!newInteractions.find(newCommand => newCommand === command))
+          ) && !newInteractions.find(newCommand => newCommand === command))
 
-          const promises: Array<Promise<any>> = [];
+          console.log(newInteractions)
+          console.log(deletedInteractions)
+          console.log(changedInteractions)
+
+          const promises: Array<Promise<any>> = []
           newInteractions.forEach(command => promises.push(this.worker.api.interactions.add(command.interaction as RESTPostAPIApplicationCommandsJSONBody, this.worker.user.id, this._options.interactionGuild)))
           deletedInteractions.forEach(interaction => promises.push(this.worker.api.interactions.delete(interaction.id, this.worker.user.id, this._options.interactionGuild)))
           changedInteractions.forEach(command => promises.push(this.worker.api.interactions.update(command.interaction as RESTPatchAPIApplicationCommandJSONBody, this.worker.user.id, currentInteractions.find(interaction => interaction.name === command.interaction?.name)?.id, this._options.interactionGuild)))

--- a/src/structures/CommandHandler.ts
+++ b/src/structures/CommandHandler.ts
@@ -1,4 +1,4 @@
-import { APIMessage, InteractionType, MessageType, RESTPatchAPIApplicationCommandJSONBody, RESTPostAPIApplicationCommandsJSONBody, Snowflake } from 'discord-api-types'
+import { APIMessage, InteractionType, MessageType, RESTPostAPIApplicationCommandsJSONBody, Snowflake } from 'discord-api-types'
 
 import { CommandContext } from './CommandContext'
 
@@ -89,7 +89,7 @@ export class CommandHandler {
 
           Promise.all(promises)
             .then(() => {
-              this.worker.log('Posted command interactions')
+              this.worker.log(`Added ${newInteractions.size}, deleted ${deletedInteractions.length}, and updated ${changedInteractions.size} command interactions`)
             })
             .catch(err => {
               err.message = `${err.message as string} (Whilst posting Command Interactions)`
@@ -262,7 +262,7 @@ export class CommandHandler {
     if (this.worker.comms.id === '0' && this.addedInteractions && command.interaction) {
       this.worker.api.interactions.add(command.interaction, this.worker.user.id, this._options.interactionGuild)
         .catch(err => {
-          err.message = `${err.message as string} (Whilst posting Command Interactions)`
+          err.message = `${err.message as string} (Whilst posting a Command Interaction)`
           console.error(err)
         })
     }

--- a/src/utils/UtilityFunctions.ts
+++ b/src/utils/UtilityFunctions.ts
@@ -57,3 +57,15 @@ export function resolveString (data: any): string {
 
   return String(data)
 }
+
+/**
+ * Traverses through all elements and nested elements of an object.
+ * @param obj The object to traverse.
+ * @param callback A callback that fires for every element of the object.
+ */
+export function traverseObject (obj: object, callback: (obj: {[key: string]: any}) => void): void {
+  callback(obj)
+  Object.keys(obj).forEach(key => {
+    if (typeof obj[key] === 'object') traverseObject(obj[key], callback)
+  })
+}


### PR DESCRIPTION
This adds a `reuseInteractions` option to the command handler. If it is set to `true`, instead of overwriting all commands for an application, it will delete, update, and add them as needed. This is useful when working with global commands, as bulk overwrites cause all cached commands to become invalid, whereas this method will preserve commands with unchanged interaction data. A real-world use for this would be faster rollouts of bot updates that don't change interaction data, as currently a bot update would result in global slash commands being unavailable for a considerable amount of time.

Additionally to make this work, `InteractionResource` has 3 new methods; `.get()` (https://github.com/discord-rose/discord-rose/commit/562152f318abc88e7e89ee9eedb7c4b2809d92fb A `GET` request that retrieves all commands for an application. Also, I pulled an oopsies and accidentally labeled the commit as `.set()`, sorry 🤪), `.delete()` (https://github.com/discord-rose/discord-rose/commit/4f81642c308991105a8045c0a8820769a2af23e4 A `DELETE` request that will delete a specified command), and `.add()` (https://github.com/discord-rose/discord-rose/commit/5d43b504f964306545c6a070bc8f5fe8c6ec1184 A `POST` request that adds a new command to the application). However, the naming scheme of these methods is a little odd, and may need to be refactored. Additionally, the method I'm using to find changed commands is a little janky, so please let me know if there is a cleaner way to go about it. Typings in `src/rest/resources/Interactions.ts` for the pre-existing methods have also changed (Not breaking) to better match the typings in `discord-api-types`.