### PR TITLE
feat: Add `voiceStates` to `CacheControlOptions`

### DIFF
--- a/src/clustering/master/Master.ts
+++ b/src/clustering/master/Master.ts
@@ -399,6 +399,7 @@ export interface CacheControlOptions {
   roles?: Array<keyof DiscordEventMap['GUILD_ROLE_CREATE']['role']> | false
   channels?: Array<keyof DiscordEventMap['CHANNEL_CREATE']> | false
   members?: Array<keyof DiscordEventMap['GUILD_MEMBER_ADD']> | false
+  voiceStates?: Array<keyof DiscordEventMap['VOICE_STATE_UPDATE']> | false
 }
 
 const Intents = {

--- a/src/socket/cache/voiceStates.ts
+++ b/src/socket/cache/voiceStates.ts
@@ -2,7 +2,7 @@ import { Worker } from '../../clustering/worker/Worker'
 import { CacheManager } from '../CacheManager'
 
 import Collection from '@discordjs/collection'
-import { Snowflake } from 'discord-api-types'
+import { GatewayVoiceState, Snowflake } from 'discord-api-types'
 import { CachedVoiceState } from '../../typings/Discord'
 
 export function voiceStates (events: CacheManager, worker: Worker): void {
@@ -42,26 +42,38 @@ export function voiceStates (events: CacheManager, worker: Worker): void {
 
   events.on('VOICE_STATE_UPDATE', (data) => {
     const currentSession = worker.voiceStates.find(x => x.users.some(x => x.session_id === data.session_id))
-    if (!data.guild_id) return
 
-    if (!currentSession && data.channel_id) {
-      const channel = getVoiceState(data.channel_id, data.guild_id)
+    let voiceState = Object.assign({}, data)
+    if (worker.options.cacheControl.voiceStates) {
+      const newVoiceState = {} as GatewayVoiceState
+      worker.options.cacheControl.voiceStates.forEach(key => {
+        newVoiceState[key] = data[key] as never
+      })
+      newVoiceState.guild_id = voiceState.guild_id
+      newVoiceState.channel_id = voiceState.channel_id
+      newVoiceState.user_id = voiceState.user_id
+      voiceState = newVoiceState
+    }
+    if (!voiceState.guild_id) return
 
-      channel.users.set(data.user_id, data)
-    } else if (currentSession && !data.channel_id) {
-      currentSession.users.delete(data.user_id)
+    if (!currentSession && voiceState.channel_id) {
+      const channel = getVoiceState(voiceState.channel_id, voiceState.guild_id)
+
+      channel.users.set(voiceState.user_id, voiceState)
+    } else if (currentSession && !voiceState.channel_id) {
+      currentSession.users.delete(voiceState.user_id)
 
       if (currentSession.users.size < 1) worker.voiceStates.delete(currentSession.channel_id)
-    } else if (currentSession && data.channel_id && currentSession.channel_id !== data.channel_id) {
-      currentSession?.users.delete(data.user_id)
+    } else if (currentSession && voiceState.channel_id && currentSession.channel_id !== voiceState.channel_id) {
+      currentSession?.users.delete(voiceState.user_id)
 
       if (currentSession.users.size < 1) worker.voiceStates.delete(currentSession.channel_id)
 
-      const channel = getVoiceState(data.channel_id, data.guild_id)
+      const channel = getVoiceState(voiceState.channel_id, voiceState.guild_id)
 
-      channel.users.set(data.user_id, data)
+      channel.users.set(voiceState.user_id, voiceState)
     } else {
-      currentSession?.users.set(data.user_id, data)
+      currentSession?.users.set(voiceState.user_id, voiceState)
     }
   })
 }


### PR DESCRIPTION
Adds more `voiceStates` to `CacheControlOptions`. Uses the same method used for `guilds`.